### PR TITLE
Support for MacOS X - whose clang compiler doesn't support OpenMP

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,14 @@
+# This is under MIT licence
+# Also, I am not at all proud of this makefile, feel free to make better
+
+all:
+	c++ -o smallvcm ./src/smallvcm.cxx -O3 -std=c++0x -stdlib=libc++ -DNO_OMP
+
+old_rng:
+	c++ -o smallvcm ./src/smallvcm.cxx -O3 -DLEGACY_RNG -DNO_OMP
+
+clean:
+	rm smallvcm
+
+unreport:
+	rm *.bmp index.html

--- a/src/config.hxx
+++ b/src/config.hxx
@@ -41,7 +41,9 @@
 #include "vertexcm.hxx"
 #include "html_writer.hxx"
 
+#ifndef NO_OMP
 #include <omp.h>
+#endif
 #include <string>
 #include <set>
 #include <sstream>

--- a/src/eyelight.hxx
+++ b/src/eyelight.hxx
@@ -27,7 +27,9 @@
 
 #include <vector>
 #include <cmath>
+#ifndef NO_OMP
 #include <omp.h>
+#endif
 #include "renderer.hxx"
 #include "rng.hxx"
 

--- a/src/smallvcm.cxx
+++ b/src/smallvcm.cxx
@@ -279,7 +279,7 @@ int main(int argc, const char *argv[])
 #ifndef NO_OMP
         config.mNumThreads = std::max(1, omp_get_num_procs());
 #else
-	config.mNumThreads = 1;
+        config.mNumThreads = 1;
 #endif
 
     if(config.mFullReport)


### PR DESCRIPTION
A useful patch for supporting MacOS X with the clang compiler - separate Makefile.osx included.